### PR TITLE
fix: GitHub Pagesでのリンク切れを修正

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,39 @@
-export default function HomePage() {
+import Link from 'next/link';
+import { promises as fs } from 'fs';
+import path from 'path';
+
+interface GameManifest {
+  name: string;
+  description: string;
+}
+
+async function getGames() {
+  const gamesDirectory = path.join(process.cwd(), 'games');
+  const gameFolders = await fs.readdir(gamesDirectory);
+
+  const games = await Promise.all(
+    gameFolders.map(async (gameFolder) => {
+      const manifestPath = path.join(gamesDirectory, gameFolder, 'manifest.json');
+      try {
+        const manifestContent = await fs.readFile(manifestPath, 'utf-8');
+        const manifest = JSON.parse(manifestContent) as GameManifest;
+        return {
+          slug: gameFolder,
+          ...manifest,
+        };
+      } catch (error) {
+        console.error(`Error reading manifest for ${gameFolder}:`, error);
+        return null;
+      }
+    })
+  );
+
+  return games.filter(game => game !== null);
+}
+
+export default async function HomePage() {
+  const games = await getGames();
+
   return (
     <main className="flex min-h-screen flex-col items-center justify-between p-24">
       <div className="z-10 w-full max-w-5xl items-center justify-between font-mono text-sm lg:flex">
@@ -7,46 +42,32 @@ export default function HomePage() {
         </p>
       </div>
 
-      <div className="relative z-[-1] flex place-items-center before:absolute before:h-[300px] before:w-full before:-translate-x-1/2 before:rounded-full before:bg-gradient-radial before:from-white before:to-transparent before:blur-2xl before:content-[''_] after:absolute after:-z-20 after:h-[180px] after:w-full after:translate-x-1/3 after:bg-gradient-conic after:from-sky-200 after:via-blue-200 after:blur-2xl after:content-[''_] before:dark:bg-gradient-to-br before:dark:from-transparent before:dark:to-blue-700 before:dark:opacity-10 after:dark:from-sky-900 after:dark:via-[#0141ff] after:dark:opacity-40 sm:before:w-[480px] sm:after:w-[240px]">
+      <div className="relative z-[-1] flex place-items-center before:absolute before:h-[300px] before:w-full before:-translate-x-1/2 before:rounded-full before:bg-gradient-radial before:from-white before:to-transparent before:blur-2xl before:content-[''] after:absolute after:-z-20 after:h-[180px] after:w-full after:translate-x-1/3 after:bg-gradient-conic after:from-sky-200 after:via-blue-200 after:blur-2xl after:content-[''] before:dark:bg-gradient-to-br before:dark:from-transparent before:dark:to-blue-700 before:dark:opacity-10 after:dark:from-sky-900 after:dark:via-[#0141ff] after:dark:opacity-40 sm:before:w-[480px] sm:after:w-[240px]">
         <h1 className="text-6xl font-bold text-center">
           Welcome to MEGH!
         </h1>
       </div>
 
       <div className="mb-32 grid text-center lg:mb-0 lg:w-full lg:max-w-5xl lg:grid-cols-4 lg:text-left">
-        <a
-          href="/games/sample-game"
-          className="group rounded-lg border border-transparent px-5 py-4 transition-colors hover:border-gray-300 hover:bg-gray-100 hover:dark:border-neutral-700 hover:dark:bg-neutral-800/30"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <h2 className="mb-3 text-2xl font-semibold">
-            Sample Game{' '}
-            <span className="inline-block transition-transform group-hover:translate-x-1 motion-reduce:transform-none">
-              -&gt;
-            </span>
-          </h2>
-          <p className="m-0 max-w-[30ch] text-sm opacity-50">
-            Play a sample game.
-          </p>
-        </a>
-
-        <a
-          href="/games/tictactoe"
-          className="group rounded-lg border border-transparent px-5 py-4 transition-colors hover:border-gray-300 hover:bg-gray-100 hover:dark:border-neutral-700 hover:dark:bg-neutral-800/30"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <h2 className="mb-3 text-2xl font-semibold">
-            Tic Tac Toe{' '}
-            <span className="inline-block transition-transform group-hover:translate-x-1 motion-reduce:transform-none">
-              -&gt;
-            </span>
-          </h2>
-          <p className="m-0 max-w-[30ch] text-sm opacity-50">
-            Play the classic Tic Tac Toe game.
-          </p>
-        </a>
+        {games.map((game) => (
+          <Link
+            key={game.slug}
+            href={`/games/${game.slug}`}
+            className="group rounded-lg border border-transparent px-5 py-4 transition-colors hover:border-gray-300 hover:bg-gray-100 hover:dark:border-neutral-700 hover:dark:bg-neutral-800/30"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <h2 className="mb-3 text-2xl font-semibold">
+              {game.name}{' '}
+              <span className="inline-block transition-transform group-hover:translate-x-1 motion-reduce:transform-none">
+                -&gt;
+              </span>
+            </h2>
+            <p className="m-0 max-w-[30ch] text-sm opacity-50">
+              {game.description}
+            </p>
+          </Link>
+        ))}
       </div>
     </main>
   );

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,11 +1,13 @@
 import type { NextConfig } from "next";
 
-const repo = process.env.GITHUB_REPOSITORY?.split('/')[1] || 'minimal-games-hub';
+// 'npm run build'時は'production'、'npm run dev'時は'development'になる
+const isProd = process.env.NODE_ENV === 'production';
 
 const nextConfig: NextConfig = {
   output: 'export',
-  basePath: `/${repo}`,
-  assetPrefix: `/${repo}/`,
+  // 本番ビルド時（GitHub Pagesデプロイ時）のみ、リポジトリ名をパスに含める
+  basePath: isProd ? '/minimal-games-hub' : undefined,
+  assetPrefix: isProd ? '/minimal-games-hub/' : undefined,
   /* config options here */
 };
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,11 @@
 import type { NextConfig } from "next";
 
+const repo = process.env.GITHUB_REPOSITORY?.split('/')[1] || 'minimal-games-hub';
+
 const nextConfig: NextConfig = {
   output: 'export',
+  basePath: `/${repo}`,
+  assetPrefix: `/${repo}/`,
   /* config options here */
 };
 


### PR DESCRIPTION
  概要

  GitHub Pagesでデプロイされた際、ゲームへのリンクが機能しない問題を修正しました。

  変更内容

   - next.config.ts に basePath と assetPrefix を設定し、GitHub PagesのURL構造に対応しました。
   - app/page.tsx を修正し、games ディレクトリから動的にゲームのリストを読み込むように変更しました。これにより、ハードコードされたリンクがなくな
     り、将来的なゲームの追加にも対応しやすくなりました。

  確認方法

   1. このブランチをデプロイします。
   2. デプロイされたページのリンクが正しく /minimal-games-hub/games/... という形式になっていることを確認します。
   3. リンクをクリックし、各ゲームページが正常に表示されることを確認します。