### PR TITLE
fix: デプロイ版のBack to Gameリンクを修正

### DIFF
--- a/app/games/[slug]/rules/page.tsx
+++ b/app/games/[slug]/rules/page.tsx
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import Link from 'next/link';
 import { GameManifest } from '@/types/game';
 import MarkdownViewer from '@/app/components/MarkdownViewer';
 
@@ -36,9 +37,9 @@ export default async function RulesPage({ params }: RulesPageProps) {
       <h1 className="text-3xl font-bold mb-4">{gameName} Rules</h1>
       <MarkdownViewer content={rulesContent} />
       <div className="mt-8">
-        <a href={`/games/${slug}`} className="text-blue-500 hover:underline">
+        <Link href={`/games/${slug}`} className="text-blue-500 hover:underline">
           Back to Game
-        </a>
+        </Link>
       </div>
     </div>
   );


### PR DESCRIPTION
GitHub Pagesのようなサブディレクトリにデプロイされた環境で、「Back to Game」リンクが機能しない問題を修正する。

主な変更点:

*   `app/games/[slug]/rules/page.tsx` の「Back to Game」リンクの `<a>` タグを `next/link` の `Link` コンポーネントに置き換える。

背景:

Next.jsの `Link` コンポーネントは `basePath` の設定を自動的に処理するため、デプロイ環境でも正しいパスに遷移できるようになる。