### PR TITLE
fix: GitHub Pagesデプロイ時の404エラーを修正

### DIFF
--- a/docs/ai-workflow/logs/system.log
+++ b/docs/ai-workflow/logs/system.log
@@ -179,3 +179,15 @@
     -   `vitest.config.ts` に `exclude: ['tests/**']` を追加し、VitestがPlaywrightのテストファイルを誤って実行する問題を解決。
     -   CI環境でのみ `basePath` を無効にする設定を `next.config.ts` に追加し、テストサーバーでの404エラーを回避。
     -   CI/CDパイプラインにE2Eテストの実行ステップを組み込み。
+
+---
+
+## 2025年8月10日
+
+-   **タスク:** GitHub Pages 404エラー修正とE2Eテストの安定化
+-   **ブランチ:** `feature/handoff-e2e-test`
+-   **作業概要:**
+    -   `next.config.ts` に `trailingSlash: true` を追加し、ビルド成果物のパスとGitHub Pagesが期待するパスの不一致を解消。
+    -   `docs/project-info/spec-top-page.md` を新規作成し、実装非依存の記述に修正。
+    -   `tests/navigation.spec.ts` に、トップページから各ゲームページへの遷移を検証するE2Eテストを新規作成し、安定化と検証範囲の調整を実施。
+    -   `docs/ai-workflow/2-technical-guide.md` にE2Eテストの規約と検証範囲に関する記述を更新。

--- a/next.config.ts
+++ b/next.config.ts
@@ -7,8 +7,8 @@ const nextConfig: NextConfig = {
   output: 'export',
   // 本番ビルド時（GitHub Pagesデプロイ時）のみ、リポジトリ名をパスに含める
   // CI環境ではテストのためにbasePathを無効化する
-  basePath: isProd && !process.env.CI ? '/minimal-games-hub' : undefined,
-  assetPrefix: isProd && !process.env.CI ? '/minimal-games-hub/' : undefined,
+  basePath: isProd ? '/minimal-games-hub' : undefined,
+  assetPrefix: isProd ? '/minimal-games-hub/' : undefined,
   trailingSlash: true,
   /* config options here */
 };


### PR DESCRIPTION
GitHub Pagesデプロイ時に発生していた404エラーを修正しました。
原因は、next.config.tsのbasePathとassetPrefixがCI環境で正しく設定されていなかったためです。

- next.config.ts:
    - basePathとassetPrefixの条件式から`!process.env.CI`を削除。
    - これにより、CI環境でのビルド時にもbasePathとassetPrefixが正しく適用され、GitHub PagesのURL構造と一致するようになります。