### PR TITLE
feat(hasami-shogi): UIレイアウトを改善し難易度選択機能を追加

### DIFF
--- a/dev.log
+++ b/dev.log
@@ -1,3 +1,10 @@
 
 > minimal-games-hub@0.1.0 dev
 > next dev -H 0.0.0.0
+
+   ▲ Next.js 15.4.4
+   - Local:        http://localhost:3000
+   - Network:      http://0.0.0.0:3000
+
+ ✓ Starting...
+ ✓ Ready in 2.1s

--- a/games/hasami-shogi/core.ts
+++ b/games/hasami-shogi/core.ts
@@ -2,6 +2,7 @@ export type Player = 'PLAYER1' | 'PLAYER2';
 export type CellState = Player | null;
 export type Board = CellState[][];
 export type WinCondition = 'standard' | 'five_captures' | 'total_capture';
+export type Difficulty = 'easy' | 'normal' | 'hard';
 
 export interface Move {
   captures: [number, number][];
@@ -21,16 +22,28 @@ export interface GameState {
     PLAYER2: number;
   };
   winCondition: WinCondition;
+  difficulty: Difficulty;
 }
 
 const BOARD_SIZE = 9;
 
-export function createInitialState(): GameState {
+export function createInitialState(difficulty: Difficulty = 'normal'): GameState {
   const board: Board = Array(BOARD_SIZE).fill(null).map(() => Array(BOARD_SIZE).fill(null));
-  for (let c = 0; c < BOARD_SIZE; c++) {
+
+  const piecesCount: { [key in Difficulty]: number } = {
+    easy: 5,
+    normal: 7,
+    hard: 9,
+  };
+  const numPieces = piecesCount[difficulty];
+  const startCol = Math.floor((BOARD_SIZE - numPieces) / 2);
+
+  for (let i = 0; i < numPieces; i++) {
+    const c = startCol + i;
     board[0][c] = 'PLAYER2';
     board[BOARD_SIZE - 1][c] = 'PLAYER1';
   }
+
   return {
     board,
     currentPlayer: 'PLAYER1',
@@ -41,11 +54,12 @@ export function createInitialState(): GameState {
     potentialCaptures: [],
     capturedPieces: { PLAYER1: 0, PLAYER2: 0 },
     winCondition: 'standard',
+    difficulty,
   };
 }
 
 export function setWinCondition(currentState: GameState, winCondition: WinCondition): GameState {
-  const initialBoard = createInitialState().board;
+  const initialBoard = createInitialState(currentState.difficulty).board;
   const isBoardInitial = currentState.board.every((row, r) =>
     row.every((cell, c) => cell === initialBoard[r][c])
   );

--- a/games/hasami-shogi/index.tsx
+++ b/games/hasami-shogi/index.tsx
@@ -4,6 +4,7 @@ import React, { useState, useCallback, CSSProperties } from 'react';
 import {
   Player,
   WinCondition,
+  Difficulty,
 } from './core';
 import { useHasamiShogi, HasamiShogiController } from './useHasamiShogi';
 import GameLayout from '../../app/components/GameLayout';
@@ -42,34 +43,45 @@ const HasamiShogi = ({ controller: externalController }: HasamiShogiProps = {}) 
   const internalController = useHasamiShogi();
   const controller = externalController || internalController;
   
-  const gameState = controller.gameState;
-  const hintLevel = controller.getHintLevel();
+  const {
+    gameState,
+    makeMove,
+    setWinCondition,
+    setDifficulty,
+    getHintLevel,
+    getSelectedPiece,
+    getValidMoves,
+    getPotentialCaptures,
+    toggleHints,
+    resetGame,
+    getDifficulty,
+    isGameStarted
+  } = controller;
+
+  const hintLevel = getHintLevel();
   const responsiveState = useResponsive();
   const isMobileLayout = isMobile(responsiveState);
 
   const onCellClick = (r: number, c: number) => {
     if (gameState.gameStatus === 'GAME_OVER') return;
-    controller.makeMove(r, c);
+    makeMove(r, c);
   };
 
   const onWinConditionChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newCondition = e.target.value as WinCondition;
-    controller.setWinCondition(newCondition);
+    setWinCondition(newCondition);
   };
 
-  const isGameStarted = gameState.capturedPieces.PLAYER1 > 0 || gameState.capturedPieces.PLAYER2 > 0 || !gameState.board.every((row, r) => row.every((cell, c) => {
-    // 初期状態のボードと比較
-    if (r === 0) return cell === 'PLAYER2';
-    if (r === 8) return cell === 'PLAYER1';
-    return cell === null;
-  }));
-
+  const onDifficultyChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newDifficulty = e.target.value as Difficulty;
+    setDifficulty(newDifficulty);
+  };
 
   const getCellStyle = (r: number, c: number): CSSProperties => {
     const style: CSSProperties = { ...styles.cell, position: 'relative' };
-    const selectedPiece = controller.getSelectedPiece();
-    const validMoves = controller.getValidMoves();
-    const potentialCaptures = controller.getPotentialCaptures();
+    const selectedPiece = getSelectedPiece();
+    const validMoves = getValidMoves();
+    const potentialCaptures = getPotentialCaptures();
     const moveKey = `${r},${c}`;
 
     // Style for selected piece
@@ -98,35 +110,68 @@ const HasamiShogi = ({ controller: externalController }: HasamiShogiProps = {}) 
   // GameLayoutを使用したレンダリング
   const gameContent = (
     <>
-      <div style={styles.winConditionSelector} data-testid="win-condition-selector">
-        <h2 style={styles.winConditionTitle}>かちかたのルール</h2>
-        <div style={isMobileLayout ? styles.radioGroup : styles.radioGroupDesktop}>
-          <label style={styles.radioLabel}>
-            <input type="radio" name="win-condition" value="standard" checked={gameState.winCondition === 'standard'} onChange={onWinConditionChange} disabled={isGameStarted} />
-            ふつうのルール
-          </label>
-          <label style={styles.radioLabel}>
-            <input type="radio" name="win-condition" value="five_captures" checked={gameState.winCondition === 'five_captures'} onChange={onWinConditionChange} disabled={isGameStarted} />
-            ５こさきどり
-          </label>
-          <label style={styles.radioLabel}>
-            <input type="radio" name="win-condition" value="total_capture" checked={gameState.winCondition === 'total_capture'} onChange={onWinConditionChange} disabled={isGameStarted} />
-            ぜんぶとる
-          </label>
+      <div style={styles.controlPanel} data-testid="h-shogi-control-panel">
+        <div style={styles.controlSection} data-testid="difficulty-selector">
+          <h2 style={styles.controlTitle}>なんいど</h2>
+          <div style={isMobileLayout ? styles.radioGroup : styles.radioGroupDesktop}>
+            <label style={styles.radioLabel}>
+              <input type="radio" name="difficulty" value="easy" checked={getDifficulty() === 'easy'} onChange={onDifficultyChange} disabled={isGameStarted()} />
+              かんたん
+            </label>
+            <label style={styles.radioLabel}>
+              <input type="radio" name="difficulty" value="normal" checked={getDifficulty() === 'normal'} onChange={onDifficultyChange} disabled={isGameStarted()} />
+              ふつう
+            </label>
+            <label style={styles.radioLabel}>
+              <input type="radio" name="difficulty" value="hard" checked={getDifficulty() === 'hard'} onChange={onDifficultyChange} disabled={isGameStarted()} />
+              むずかしい
+            </label>
+          </div>
         </div>
-      </div>
 
-      <div style={styles.infoPanel}>
-        <div style={{...styles.score, ...styles.infoPanelItem, justifyContent: 'flex-start'}}>
-          <IndicatorPiece player="PLAYER2" />
-          <span data-testid="opponent-score" style={{marginLeft: '0.5rem'}}>x {gameState.capturedPieces.PLAYER1}</span>
+        <div style={styles.controlSection} data-testid="win-condition-selector">
+          <h2 style={styles.controlTitle}>かちかたのルール</h2>
+          <div style={isMobileLayout ? styles.radioGroup : styles.radioGroupDesktop}>
+            <label style={styles.radioLabel}>
+              <input type="radio" name="win-condition" value="standard" checked={gameState.winCondition === 'standard'} onChange={onWinConditionChange} disabled={isGameStarted()} />
+              ふつうのルール
+            </label>
+            <label style={styles.radioLabel}>
+              <input type="radio" name="win-condition" value="five_captures" checked={gameState.winCondition === 'five_captures'} onChange={onWinConditionChange} disabled={isGameStarted()} />
+              ５こさきどり
+            </label>
+            <label style={styles.radioLabel}>
+              <input type="radio" name="win-condition" value="total_capture" checked={gameState.winCondition === 'total_capture'} onChange={onWinConditionChange} disabled={isGameStarted()} />
+              ぜんぶとる
+            </label>
+          </div>
         </div>
-        <div data-testid="turn-indicator" style={{...styles.turnIndicator, ...styles.infoPanelItem}}>
-          {winner ? 'おしまい' : (gameState.currentPlayer === 'PLAYER1' ? '「歩」のばん' : '「と」のばん')}
+
+        <div style={styles.infoPanel}>
+          <div style={{...styles.score, ...styles.infoPanelItem, justifyContent: 'flex-start'}}>
+            <IndicatorPiece player="PLAYER2" />
+            <span data-testid="opponent-score" style={{marginLeft: '0.5rem'}}>x {gameState.capturedPieces.PLAYER1}</span>
+          </div>
+          <div data-testid="turn-indicator" style={{...styles.turnIndicator, ...styles.infoPanelItem}}>
+            {winner ? 'おしまい' : (gameState.currentPlayer === 'PLAYER1' ? '「歩」のばん' : '「と」のばん')}
+          </div>
+          <div style={{...styles.score, ...styles.infoPanelItem, justifyContent: 'flex-end'}}>
+            <IndicatorPiece player="PLAYER1" />
+            <span data-testid="player-score" style={{marginLeft: '0.5rem'}}>x {gameState.capturedPieces.PLAYER2}</span>
+          </div>
         </div>
-        <div style={{...styles.score, ...styles.infoPanelItem, justifyContent: 'flex-end'}}>
-          <IndicatorPiece player="PLAYER1" />
-          <span data-testid="player-score" style={{marginLeft: '0.5rem'}}>x {gameState.capturedPieces.PLAYER2}</span>
+
+        <div style={{...styles.controlSection, ...(isMobileLayout ? styles.buttonGroup : styles.buttonGroupDesktop)}}>
+          <button
+            data-testid="hint-button"
+            onClick={toggleHints}
+            style={{
+              ...(isMobileLayout ? styles.resetButton : styles.resetButtonDesktop),
+              backgroundColor: hintLevel === 'on' ? '#4a5568' : '#a0aec0'
+            }}
+          >
+            ヒント: {hintLevel === 'on' ? 'ON' : 'OFF'}
+          </button>
         </div>
       </div>
 
@@ -150,20 +195,6 @@ const HasamiShogi = ({ controller: externalController }: HasamiShogiProps = {}) 
         )}
       </div>
 
-      {/* ゲーム内ヒント切り替えボタン */}
-      <div style={isMobileLayout ? styles.buttonGroup : styles.buttonGroupDesktop}>
-        <button
-          data-testid="hint-button"
-          onClick={controller.toggleHints}
-          style={{
-            ...(isMobileLayout ? styles.resetButton : styles.resetButtonDesktop), 
-            backgroundColor: hintLevel === 'on' ? '#4a5568' : '#a0aec0'
-          }}
-        >
-          ヒント: {hintLevel === 'on' ? 'ON' : 'OFF'}
-        </button>
-      </div>
-
       {winner && (
         <div data-testid="game-over-modal" style={styles.gameOverOverlay}>
           <div style={styles.gameOverModal}>
@@ -175,7 +206,7 @@ const HasamiShogi = ({ controller: externalController }: HasamiShogiProps = {}) 
               }
               <span>のかち！</span>
             </div>
-            <button data-testid="play-again-button" onClick={controller.resetGame} style={isMobileLayout ? styles.resetButton : styles.resetButtonDesktop}>
+            <button data-testid="play-again-button" onClick={resetGame} style={isMobileLayout ? styles.resetButton : styles.resetButtonDesktop}>
               もういちど
             </button>
           </div>

--- a/games/hasami-shogi/styles.ts
+++ b/games/hasami-shogi/styles.ts
@@ -14,7 +14,10 @@ export const styles: { [key: string]: CSSProperties } = StyleSheet.create({
     fontWeight: 'bold',
     marginBottom: '1rem',
   },
-  winConditionSelector: {
+  controlPanel: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '1rem',
     marginBottom: '1.5rem',
     padding: '1rem',
     border: '1px solid #ccc',
@@ -24,7 +27,10 @@ export const styles: { [key: string]: CSSProperties } = StyleSheet.create({
     maxWidth: '400px',
     boxSizing: 'border-box',
   },
-  winConditionTitle: {
+  controlSection: {
+    // Sections within the control panel
+  },
+  controlTitle: {
     margin: '0 0 0.5rem 0',
     fontSize: '1.1rem',
     fontWeight: 'bold',
@@ -52,9 +58,11 @@ export const styles: { [key: string]: CSSProperties } = StyleSheet.create({
     justifyContent: 'space-around',
     alignItems: 'center',
     width: '100%',
-    maxWidth: '400px',
-    marginBottom: '1rem',
     fontSize: '1.2rem',
+    padding: '0.5rem 0',
+    borderTop: '1px solid #e2e8f0',
+    borderBottom: '1px solid #e2e8f0',
+    marginTop: '0.5rem',
   },
   infoPanelItem: {
     width: '33%',


### PR DESCRIPTION
はさみ将棋のゲーム画面において、操作系のUIが散在し、特にモバイル表示でレイアウトが煩雑になっていた問題を解決します。

- 難易度選択、勝利条件、ヒントボタン、情報表示（手番・スコア）を単一のコントロールパネルに統合し、UIを整理しました。
- 難易度選択機能（かんたん・ふつう・むずかしい）を新たに追加しました。
- 上記の変更に合わせてE2Eテストを修正しました。