### PR TITLE
fix: ゲーム対戦画面の全てのヘッダーとフッターを削除

### DIFF
--- a/app/components/AppLayout.tsx
+++ b/app/components/AppLayout.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import React from 'react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import StyleSheet from '../styles/StyleSheet';
+
+const footerStyle = StyleSheet.create({
+  footer: {
+    backgroundColor: '#1f2937', // bg-gray-800
+    color: '#ffffff', // text-white
+    padding: '1rem', // p-4
+    marginTop: '2rem', // mt-8
+  },
+  container: {
+    margin: '0 auto',
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    textAlign: 'center',
+  },
+  nav: {
+    marginTop: '0.5rem',
+  },
+  ul: {
+    display: 'flex',
+    listStyle: 'none',
+    padding: 0,
+    gap: '1rem',
+  },
+  link: {
+    textDecoration: 'none',
+    color: 'white',
+  },
+  linkHover: {
+    textDecoration: 'underline',
+  }
+});
+
+export default function AppLayout({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  const isGamePage = pathname.startsWith('/games/');
+
+  return (
+    <>
+      {!isGamePage && (
+        <header>
+          <h1>
+            <Link href="/">Minimal Games Hub</Link>
+          </h1>
+        </header>
+      )}
+      <main>{children}</main>
+      {!isGamePage && (
+        <footer style={footerStyle.footer}>
+          <div style={footerStyle.container}>
+            <p>&copy; 2025 Minimal Games Hub</p>
+            <nav style={footerStyle.nav}>
+              <ul style={footerStyle.ul}>
+                <li>
+                  <Link href="/license">
+                    <p style={footerStyle.link}>Licenses</p>
+                  </Link>
+                </li>
+                <li>
+                  <a href="https://github.com/Ishikawa-Taiki/minimal-games-hub" target="_blank" rel="noopener noreferrer" style={footerStyle.link}>GitHub Repository</a>
+                </li>
+              </ul>
+            </nav>
+          </div>
+        </footer>
+      )}
+    </>
+  );
+}

--- a/app/components/GameLayout.tsx
+++ b/app/components/GameLayout.tsx
@@ -188,17 +188,6 @@ export default function GameLayout<TState extends BaseGameState, TAction>({
     console.log('Using legacy layout - gameController is undefined');
     return (
       <div style={gameLayoutStyles.container}>
-        <header style={gameLayoutStyles.header}>
-          <h1 style={gameLayoutStyles.headerTitle}>{gameName}</h1>
-          <div style={gameLayoutStyles.linksContainer}>
-            <Link href={`/games/${slug}/rules`} style={{ ...gameLayoutStyles.link, ...gameLayoutStyles.rulesLink }}>
-              Rules
-            </Link>
-            <Link href="/" style={{ ...gameLayoutStyles.link, ...gameLayoutStyles.homeLink }}>
-              Back to Home
-            </Link>
-          </div>
-        </header>
         <main style={gameLayoutStyles.main}>
           {children}
         </main>
@@ -211,34 +200,6 @@ export default function GameLayout<TState extends BaseGameState, TAction>({
     // モバイルレイアウト: ミニマルレイアウト + FAB + ボトムシート
     return (
       <div style={gameLayoutStyles.mobileContainer}>
-        {/* スリムヘッダー */}
-        <header style={gameLayoutStyles.mobileHeader}>
-          <h1 style={gameLayoutStyles.mobileHeaderTitle}>{gameName}</h1>
-          <div style={gameLayoutStyles.mobileStatus} data-testid="status">
-            {(() => {
-              // ポリモーフィック設計: 各ゲームコントローラーが自身の状態表示ロジックを持つ
-              if ('getDisplayStatus' in gameController && typeof gameController.getDisplayStatus === 'function') {
-                return gameController.getDisplayStatus();
-              }
-              
-              // フォールバック: 汎用的な状態表示
-              if (gameController.gameState.winner) {
-                if (gameController.gameState.winner === 'DRAW') {
-                  return '引き分け！';
-                }
-                return `勝者: ${gameController.gameState.winner}`;
-              } else if (gameController.gameState.status === 'ended') {
-                const extendedState = gameController.gameState as TState & { isDraw?: boolean };
-                return extendedState.isDraw ? '引き分け！' : 'ゲーム終了';
-              } else if ((gameController.gameState.status === 'playing' || gameController.gameState.status === 'waiting') && gameController.gameState.currentPlayer) {
-                return `${gameController.gameState.currentPlayer}の番`;
-              } else {
-                return 'ゲーム開始';
-              }
-            })()}
-          </div>
-        </header>
-
         {/* ゲームボード（フルエリア） */}
         <main style={gameLayoutStyles.mobileMain}>
           {children}
@@ -277,9 +238,6 @@ export default function GameLayout<TState extends BaseGameState, TAction>({
       <div style={gameLayoutStyles.desktopContainer}>
         {/* サイドバー（コントロールパネル） */}
         <aside style={gameLayoutStyles.sidebar}>
-          <div style={gameLayoutStyles.sidebarHeader}>
-            <h1 style={gameLayoutStyles.sidebarTitle}>{gameName}</h1>
-          </div>
           <ControlPanel
             gameController={gameController}
             slug={slug}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,43 +1,10 @@
-import Link from 'next/link';
-import StyleSheet from './styles/StyleSheet';
+import AppLayout from './components/AppLayout';
 import React from 'react';
 
 const bodyStyle: React.CSSProperties = {
   font: '14px "Century Gothic", Futura, sans-serif',
   margin: '20px',
 };
-
-const footerStyle = StyleSheet.create({
-  footer: {
-    backgroundColor: '#1f2937', // bg-gray-800
-    color: '#ffffff', // text-white
-    padding: '1rem', // p-4
-    marginTop: '2rem', // mt-8
-  },
-  container: {
-    margin: '0 auto',
-    display: 'flex',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    textAlign: 'center',
-  },
-  nav: {
-    marginTop: '0.5rem',
-  },
-  ul: {
-    display: 'flex',
-    listStyle: 'none',
-    padding: 0,
-    gap: '1rem',
-  },
-  link: {
-    textDecoration: 'none',
-    color: 'white',
-  },
-  linkHover: {
-    textDecoration: 'underline',
-  }
-});
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
@@ -60,24 +27,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         `}</style>
       </head>
       <body style={bodyStyle}>
-        {children}
-        <footer style={footerStyle.footer}>
-          <div style={footerStyle.container}>
-            <p>&copy; 2025 Minimal Games Hub</p>
-            <nav style={footerStyle.nav}>
-              <ul style={footerStyle.ul}>
-                <li>
-                  <Link href="/license">
-                    <p style={footerStyle.link}>Licenses</p>
-                  </Link>
-                </li>
-                <li>
-                  <a href="https://github.com/Ishikawa-Taiki/minimal-games-hub" target="_blank" rel="noopener noreferrer" style={footerStyle.link}>GitHub Repository</a>
-                </li>
-              </ul>
-            </nav>
-          </div>
-        </footer>
+        <AppLayout>{children}</AppLayout>
       </body>
     </html>
   );


### PR DESCRIPTION
ゲームプレイに集中できるよう、対戦画面からヘッダーとフッターを完全に削除しました。

前回の修正で、一部のゲーム画面にヘッダーが残ってしまう問題がありましたが、本修正で`GameLayout`コンポーネント内のヘッダーも削除し、すべてのゲーム画面でヘッダーとフッターが非表示になるようにしました。

- `AppLayout` コンポーネントを新設し、URLのパスに応じてサイト全体のヘッダーとフッターの表示を切り替えるようにしました。
- `GameLayout` コンポーネントから、ゲーム固有のヘッダー表示を削除しました。
- これにより、ゲームページ (`/games/*`) では全てのヘッダーとフッターが非表示になります。
- トップページやその他のページでは、これまで通りヘッダーとフッターが表示されます。