### PR TITLE
feat: ゲーム開始前の設定画面を導入しUI/UXを統一

### DIFF
--- a/games/concentration/index.tsx
+++ b/games/concentration/index.tsx
@@ -5,11 +5,30 @@ import { BoardCard, Suit, Difficulty } from './core';
 import { styles } from './styles';
 import { useConcentration } from './useConcentration';
 import { useResponsive } from '../../hooks/useResponsive';
+import GameLayout from '../../app/components/GameLayout';
+import { PositiveButton } from '../../app/components/ui';
 
 interface ConcentrationProps {
   controller?: ReturnType<typeof useConcentration>;
   slug?: string;
 }
+
+const PreGameScreen = ({ onSelect }: { onSelect: (difficulty: Difficulty) => void }) => (
+  <div style={styles.preGameContainer} data-testid="pre-game-screen">
+    <h2 style={styles.preGameTitle}>難易度を選んでください</h2>
+    <div style={styles.preGameButtonContainer}>
+      <PositiveButton onClick={() => onSelect('easy')} data-testid="difficulty-easy">
+        かんたん
+      </PositiveButton>
+      <PositiveButton onClick={() => onSelect('normal')} data-testid="difficulty-normal">
+        ふつう
+      </PositiveButton>
+      <PositiveButton onClick={() => onSelect('hard')} data-testid="difficulty-hard">
+        むずかしい
+      </PositiveButton>
+    </div>
+  </div>
+);
 
 const Concentration = ({ controller, slug = 'concentration' }: ConcentrationProps) => {
   const gameController = controller || useConcentration('easy');
@@ -20,7 +39,6 @@ const Concentration = ({ controller, slug = 'concentration' }: ConcentrationProp
     getDifficulty,
     getBoard,
     getHintedIndices,
-    isGameStarted,
     resetGame,
     hintState,
   } = gameController;
@@ -36,11 +54,6 @@ const Concentration = ({ controller, slug = 'concentration' }: ConcentrationProp
 
   const onCardClick = (index: number) => {
     handleCardClick(index);
-  };
-
-  const handleDifficultyChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const newDifficulty = e.target.value as Difficulty;
-    setDifficulty(newDifficulty);
   };
 
   const difficulty = getDifficulty();
@@ -146,27 +159,8 @@ const Concentration = ({ controller, slug = 'concentration' }: ConcentrationProp
     ...getBoardDimensions(),
   };
 
-  return (
+  const gameContent = (
     <div style={styles.gameContent}>
-      {!isGameStarted() && (
-        <div style={styles.difficultySelector} data-testid="difficulty-selector">
-          <h2 style={styles.difficultyTitle}>難易度選択</h2>
-          <div style={styles.radioGroup}>
-            <label style={styles.radioLabel}>
-              <input type="radio" name="difficulty" value="easy" checked={difficulty === 'easy'} onChange={handleDifficultyChange} disabled={isGameStarted()} />
-              かんたん
-            </label>
-            <label style={styles.radioLabel}>
-              <input type="radio" name="difficulty" value="normal" checked={difficulty === 'normal'} onChange={handleDifficultyChange} disabled={isGameStarted()} />
-              ふつう
-            </label>
-            <label style={styles.radioLabel}>
-              <input type="radio" name="difficulty" value="hard" checked={difficulty === 'hard'} onChange={handleDifficultyChange} disabled={isGameStarted()} />
-              むずかしい
-            </label>
-          </div>
-        </div>
-      )}
       <div style={styles.boardContainer}>
         <div style={boardStyle}>
           {board.map((card, index) => (
@@ -176,6 +170,16 @@ const Concentration = ({ controller, slug = 'concentration' }: ConcentrationProp
       </div>
       <GameOverModal winner={gameState.winner} onReset={() => resetGame()} />
     </div>
+  );
+
+  return (
+    <>
+      {gameState.status === 'waiting' ? (
+        <PreGameScreen onSelect={setDifficulty} />
+      ) : (
+        gameContent
+      )}
+    </>
   );
 };
 

--- a/games/concentration/styles.ts
+++ b/games/concentration/styles.ts
@@ -187,4 +187,24 @@ export const styles: { [key: string]: CSSProperties } = StyleSheet.create({
     fontSize: '1.25rem',
     marginBottom: '1.5rem',
   },
+  preGameContainer: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: '2rem',
+    gap: '1.5rem',
+  },
+  preGameTitle: {
+    fontSize: '1.5rem',
+    fontWeight: 'bold',
+    textAlign: 'center',
+  },
+  preGameButtonContainer: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '1rem',
+    width: '100%',
+    maxWidth: '300px',
+  },
 });

--- a/games/concentration/useConcentration.test.ts
+++ b/games/concentration/useConcentration.test.ts
@@ -15,7 +15,7 @@ describe('useConcentration', () => {
     it('デフォルト設定（easy）で正しく初期化される', () => {
       const { result } = renderHook(() => useConcentration());
       
-      expect(result.current.gameState.status).toBe('playing');
+      expect(result.current.gameState.status).toBe('waiting');
       expect(result.current.gameState.currentPlayer).toBe('player1');
       expect(result.current.gameState.winner).toBeNull();
       expect(result.current.getDifficulty()).toBe('easy');
@@ -141,6 +141,7 @@ describe('useConcentration', () => {
       
       // ゲームを進行させる
       act(() => {
+        result.current.setDifficulty('normal');
         result.current.handleCardClick(0);
         result.current.handleCardClick(1);
       });
@@ -150,7 +151,7 @@ describe('useConcentration', () => {
         result.current.resetGame();
       });
       
-      expect(result.current.gameState.status).toBe('playing');
+      expect(result.current.gameState.status).toBe('waiting');
       expect(result.current.gameState.currentPlayer).toBe('player1');
       expect(result.current.gameState.winner).toBeNull();
       expect(result.current.getScores()).toEqual({ player1: 0, player2: 0 });

--- a/games/concentration/useConcentration.ts
+++ b/games/concentration/useConcentration.ts
@@ -43,7 +43,7 @@ function createInitialConcentrationState(difficulty: Difficulty = 'easy'): Conce
     gameStatus: coreState.status,
     difficulty,
     // BaseGameState required fields
-    status: 'playing' as GameStatus,
+    status: 'waiting' as GameStatus,
     winner: coreState.winner === 'draw' ? 'DRAW' : 
             coreState.winner === 1 ? 'player1' :
             coreState.winner === 2 ? 'player2' : null,
@@ -129,8 +129,13 @@ function concentrationReducer(state: ConcentrationGameState, action: Concentrati
         hintsEnabled: action.enabled,
       };
     
-    case 'SET_DIFFICULTY':
-      return createInitialConcentrationState(action.difficulty);
+    case 'SET_DIFFICULTY': {
+      const newState = createInitialConcentrationState(action.difficulty);
+      return {
+        ...newState,
+        status: 'playing' as GameStatus,
+      };
+    }
     
     default:
       return state;

--- a/games/hasami-shogi/index.tsx
+++ b/games/hasami-shogi/index.tsx
@@ -8,7 +8,7 @@ import {
 import { useHasamiShogi, HasamiShogiController } from './useHasamiShogi';
 import GameLayout from '../../app/components/GameLayout';
 import { useResponsive, isMobile } from '../../hooks/useResponsive';
-import { SelectableButton } from '../../app/components/ui';
+import { PositiveButton } from '../../app/components/ui';
 import { styles } from './styles';
 
 // Piece component for the game board
@@ -32,6 +32,23 @@ const IndicatorPiece: React.FC<{ player: Player }> = ({ player }) => {
   return <div style={pieceStyle}>{char}</div>;
 };
 
+const PreGameScreen = ({ onSelect }: { onSelect: (condition: WinCondition) => void }) => (
+  <div style={styles.preGameContainer} data-testid="pre-game-screen">
+    <h2 style={styles.preGameTitle}>勝利条件を選んでください</h2>
+    <div style={styles.preGameButtonContainer}>
+      <PositiveButton onClick={() => onSelect('standard')} data-testid="win-cond-standard">
+        ふつうのルール (8個先取)
+      </PositiveButton>
+      <PositiveButton onClick={() => onSelect('five_captures')} data-testid="win-cond-five">
+        5こさきどり
+      </PositiveButton>
+      <PositiveButton onClick={() => onSelect('total_capture')} data-testid="win-cond-total">
+        ぜんぶとる
+      </PositiveButton>
+    </div>
+  </div>
+);
+
 
 // プロップスでコントローラーを受け取るバージョン
 interface HasamiShogiProps {
@@ -53,7 +70,6 @@ const HasamiShogi = ({ controller: externalController }: HasamiShogiProps = {}) 
     setHints,
     hintState,
     resetGame,
-    isGameStarted
   } = controller;
 
   const hintsEnabled = hintState.enabled;
@@ -63,11 +79,6 @@ const HasamiShogi = ({ controller: externalController }: HasamiShogiProps = {}) 
   const onCellClick = (r: number, c: number) => {
     if (gameState.gameStatus === 'GAME_OVER') return;
     makeMove(r, c);
-  };
-
-  const onWinConditionChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const newCondition = e.target.value as WinCondition;
-    setWinCondition(newCondition);
   };
 
   const getCellStyle = (r: number, c: number): CSSProperties => {
@@ -100,30 +111,8 @@ const HasamiShogi = ({ controller: externalController }: HasamiShogiProps = {}) 
 
   const winner = gameState.winner;
 
-  // GameLayoutを使用したレンダリング
   const gameContent = (
     <>
-      <div style={styles.controlPanel} data-testid="h-shogi-control-panel">
-        <div style={styles.controlSection} data-testid="win-condition-selector">
-          <h2 style={styles.controlTitle}>かちかたのルール</h2>
-          <div style={isMobileLayout ? styles.radioGroup : styles.radioGroupDesktop}>
-            <label style={styles.radioLabel}>
-              <input type="radio" name="win-condition" value="standard" checked={gameState.winCondition === 'standard'} onChange={onWinConditionChange} disabled={isGameStarted()} />
-              ふつうのルール
-            </label>
-            <label style={styles.radioLabel}>
-              <input type="radio" name="win-condition" value="five_captures" checked={gameState.winCondition === 'five_captures'} onChange={onWinConditionChange} disabled={isGameStarted()} />
-              ５こさきどり
-            </label>
-            <label style={styles.radioLabel}>
-              <input type="radio" name="win-condition" value="total_capture" checked={gameState.winCondition === 'total_capture'} onChange={onWinConditionChange} disabled={isGameStarted()} />
-              ぜんぶとる
-            </label>
-          </div>
-        </div>
-
-      </div>
-
       <div style={styles.board}>
         {gameState.board.map((row, r) =>
           row.map((cell, c) => {
@@ -168,7 +157,15 @@ const HasamiShogi = ({ controller: externalController }: HasamiShogiProps = {}) 
     </>
   );
 
-  return gameContent;
+  return (
+    <>
+      {gameState.status === 'waiting' ? (
+        <PreGameScreen onSelect={setWinCondition} />
+      ) : (
+        gameContent
+      )}
+    </>
+  );
 };
 
 // GameControllerを外部に公開するためのラッパーコンポーネント

--- a/games/hasami-shogi/styles.ts
+++ b/games/hasami-shogi/styles.ts
@@ -185,5 +185,25 @@ export const styles: { [key: string]: CSSProperties } = StyleSheet.create({
     backgroundColor: 'rgba(255, 255, 255, 0.5)',
     borderRadius: '2px',
     pointerEvents: 'none',
-  }
+  },
+  preGameContainer: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: '2rem',
+    gap: '1.5rem',
+  },
+  preGameTitle: {
+    fontSize: '1.5rem',
+    fontWeight: 'bold',
+    textAlign: 'center',
+  },
+  preGameButtonContainer: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '1rem',
+    width: '100%',
+    maxWidth: '300px',
+  },
 });

--- a/games/hasami-shogi/useHasamiShogi.test.ts
+++ b/games/hasami-shogi/useHasamiShogi.test.ts
@@ -8,7 +8,7 @@ describe('useHasamiShogi', () => {
     it('初期状態が正しく設定される', () => {
       const { result } = renderHook(() => useHasamiShogi());
       
-      expect(result.current.gameState.status).toBe('playing');
+      expect(result.current.gameState.status).toBe('waiting');
       expect(result.current.gameState.currentPlayer).toBe('PLAYER1');
       expect(result.current.gameState.winner).toBeNull();
       expect(result.current.gameState.hintsEnabled).toBe(false);
@@ -44,6 +44,10 @@ describe('useHasamiShogi', () => {
     it('resetGameで初期状態に戻る', () => {
       const { result } = renderHook(() => useHasamiShogi());
       
+      act(() => {
+        result.current.setWinCondition('five_captures');
+      });
+
       // ヒントをオンにして状態を変更
       act(() => {
         result.current.setHints(true);
@@ -56,7 +60,7 @@ describe('useHasamiShogi', () => {
         result.current.resetGame();
       });
       
-      expect(result.current.gameState.status).toBe('playing');
+      expect(result.current.gameState.status).toBe('waiting');
       expect(result.current.gameState.currentPlayer).toBe('PLAYER1');
       expect(result.current.gameState.winner).toBeNull();
       expect(result.current.gameState.hintsEnabled).toBe(false);

--- a/games/hasami-shogi/useHasamiShogi.ts
+++ b/games/hasami-shogi/useHasamiShogi.ts
@@ -29,7 +29,7 @@ function createInitialHasamiShogiState(): HasamiShogiGameState {
   return {
     ...coreState,
     // BaseGameState required fields
-    status: 'playing' as GameStatus,
+    status: 'waiting' as GameStatus,
     winner: null,
     // ヒント関連
     hintsEnabled: false,
@@ -90,6 +90,7 @@ function hasamiShogiReducer(state: HasamiShogiGameState, action: HasamiShogiActi
       return {
         ...state,
         ...newCoreState,
+        status: 'playing',
         // BaseGameState必須フィールドを明示的に更新
         currentPlayer: newCoreState.currentPlayer,
         winner: newCoreState.winner,

--- a/games/stick-taking/index.tsx
+++ b/games/stick-taking/index.tsx
@@ -73,9 +73,9 @@ const StickTakingGame = ({ controller: externalController }: StickTakingGameProp
       <h1 style={styles.title}>ぼうけしゲーム</h1>
       <h2 style={styles.subtitle}>むずかしさをえらんでね</h2>
       <div style={styles.difficultyButtons}>
-        <Button size="large" onClick={() => handleDifficultySelect('easy')}>かんたん (3だん)</Button>
-        <Button size="large" onClick={() => handleDifficultySelect('normal')}>ふつう (5だん)</Button>
-        <Button size="large" onClick={() => handleDifficultySelect('hard')}>むずかしい (7だん)</Button>
+        <PositiveButton size="large" onClick={() => handleDifficultySelect('easy')}>かんたん (3だん)</PositiveButton>
+        <PositiveButton size="large" onClick={() => handleDifficultySelect('normal')}>ふつう (5だん)</PositiveButton>
+        <PositiveButton size="large" onClick={() => handleDifficultySelect('hard')}>むずかしい (7だん)</PositiveButton>
       </div>
     </div>
   );

--- a/tests/concentration.spec.ts
+++ b/tests/concentration.spec.ts
@@ -8,10 +8,10 @@ test.describe('神経衰弱ゲーム', () => {
 
   test('初期表示と難易度選択', async ({ page }) => {
     // 初期表示の確認
-    await expect(page.getByRole('heading', { name: '難易度選択' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: '難易度を選んでください' })).toBeVisible();
 
     // 難易度を選択
-    await page.getByLabel('かんたん').click();
+    await page.getByTestId('difficulty-easy').click();
 
     // ゲームボードが表示されることを確認
     await expect(page.locator('[data-testid^="card-"]')).toHaveCount(20);

--- a/tests/hasami-shogi.spec.ts
+++ b/tests/hasami-shogi.spec.ts
@@ -7,6 +7,7 @@ test.describe('はさみ将棋ゲームのE2Eテスト', () => {
 
   test.describe('初期表示', () => {
     test('盤面と駒が正しく表示される', async ({ page }) => {
+      await page.getByTestId('win-cond-standard').click();
       // 9x9のマスが存在することを確認
       await page.waitForSelector('[data-testid="cell-0-0"]');
       const cells = await page.locator('[data-testid^="cell-"]').all();
@@ -25,6 +26,7 @@ test.describe('はさみ将棋ゲームのE2Eテスト', () => {
 
   test.describe('駒の移動と選択', () => {
     test('駒を選択すると選択状態になり、再度クリックすると選択が解除される', async ({ page }) => {
+      await page.getByTestId('win-cond-standard').click();
       const piece = page.locator('[data-testid="cell-8-0"]');
 
       // 最初は選択されていない
@@ -40,6 +42,7 @@ test.describe('はさみ将棋ゲームのE2Eテスト', () => {
     });
 
     test('駒を選択した後に別の自分の駒を選択すると、選択が切り替わる', async ({ page }) => {
+      await page.getByTestId('win-cond-standard').click();
       const piece1 = page.locator('[data-testid="cell-8-0"]');
       const piece2 = page.locator('[data-testid="cell-8-1"]');
 
@@ -75,6 +78,7 @@ test.describe('はさみ将棋ゲームのE2Eテスト', () => {
     // });
 
     test('他の駒を飛び越えて移動することはできない', async ({ page }) => {
+      await page.getByTestId('win-cond-standard').click();
       // 8-0 の駒を 8-2 の前に移動させる
       await page.locator('[data-testid="cell-8-0"]').click();
       await page.locator('[data-testid="cell-7-0"]').click();
@@ -93,6 +97,7 @@ test.describe('はさみ将棋ゲームのE2Eテスト', () => {
 
   test.describe('駒の捕獲', () => {
     test('相手の駒を挟むと、その駒を捕獲できる', async ({ page }) => {
+      await page.getByTestId('win-cond-standard').click();
       // 捕獲のセットアップ
       // 1. 先手: (8,1) -> (1,1)
       await page.locator('[data-testid="cell-8-1"]').click();


### PR DESCRIPTION
棒取りゲーム、はさみ将棋、神経衰弱の3つのゲームに対して、UI/UXのフローを統一するための変更を実装しました。

- 棒取りゲーム: 難易度選択ボタンを`<PositiveButton>`に置き換えました。
- はさみ将棋: ゲーム開始前に勝利条件を選択する画面を導入しました。
- 神経衰弱: ゲーム開始前に難易度を選択する画面を導入しました。

状態管理フックを更新し、'waiting'状態を追加してゲーム開始フローを制御するようにしました。また、関連する単体テストおよびE2Eテストを新しい仕様に合わせて修正しました。

fix: ヘッダーの二重表示問題を修正

`GameLayout`がページレベルで適用されているため、各ゲームコンポーネント内での不要な`GameLayout`ラッパーを削除し、ヘッダーが正しく表示されるように修正しました。