### PR TITLE
refactor: next lintからeslintへの移行とエラー修正

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,8 +9,8 @@ const compat = new FlatCompat({
   baseDirectory: __dirname,
 });
 
-const eslintConfig = [
-  ...compat.extends("next/core-web-vitals", "next/typescript"),
-];
+const eslintConfig = [{
+  ignores: ["node_modules/**", ".next/**", "out/**", "build/**", "next-env.d.ts"]
+}, ...compat.extends("next/core-web-vitals", "next/typescript")];
 
 export default eslintConfig;

--- a/games/animal-chess/core.test.ts
+++ b/games/animal-chess/core.test.ts
@@ -126,7 +126,7 @@ describe('Animal Chess Core Logic', () => {
   });
 
   it('should return valid drop locations', () => {
-    let state = createInitialState();
+    const state = createInitialState();
     state.capturedPieces[SENTE] = [CHICK];
     const drops = getValidDrops(state, SENTE);
     // Initial board has 12 total cells, 8 are occupied -> 4 empty cells

--- a/games/concentration/index.tsx
+++ b/games/concentration/index.tsx
@@ -32,7 +32,8 @@ const PreGameScreen = ({ onSelect }: { onSelect: (difficulty: Difficulty) => voi
 );
 
 const Concentration = ({ controller, slug = 'concentration' }: ConcentrationProps) => {
-  const gameController = controller || useConcentration('easy');
+  const concentrationHook = useConcentration('easy');
+  const gameController = controller || concentrationHook;
   const {
     gameState,
     handleCardClick,

--- a/games/hasami-shogi/useHasamiShogi.ts
+++ b/games/hasami-shogi/useHasamiShogi.ts
@@ -1,6 +1,6 @@
 import { useReducer, useCallback, useMemo } from 'react';
 import { BaseGameController, HintableGameController, BaseGameState, GameStatus, HintState, ScoreInfo } from '../../types/game';
-import { GameState, createInitialState, handleCellClick as handleCellClickCore, Player, WinCondition, setWinCondition } from './core';
+import { GameState, createInitialState, handleCellClick as handleCellClickCore, Player, WinCondition, setWinCondition, Move } from './core';
 import { useGameStateLogger } from '../../hooks/useGameStateLogger';
 
 // はさみ将棋固有の状態をBaseGameStateに適合させる
@@ -108,7 +108,7 @@ export type HasamiShogiController = BaseGameController<HasamiShogiGameState, Has
     makeMove: (row: number, col: number) => void;
     setWinCondition: (winCondition: WinCondition) => void;
     // 状態アクセサー
-    getValidMoves: () => Map<string, any>;
+    getValidMoves: () => Map<string, Move>;
     getCurrentPlayer: () => Player;
     getCapturedPieces: () => { PLAYER1: number; PLAYER2: number };
     getWinCondition: () => WinCondition;

--- a/games/reversi/core.test.ts
+++ b/games/reversi/core.test.ts
@@ -44,7 +44,7 @@ describe('Reversi Core Logic', () => {
 
     // パスが発生するシナリオを処理することを確認
   it('パスが発生するシナリオを処理することを確認', () => {
-    let state: GameState = {
+    const state: GameState = {
       board: [
         [null, null, null, null, null, null, null, null],
         [null, null, null, null, null, null, null, null],
@@ -77,7 +77,7 @@ describe('Reversi Core Logic', () => {
 
   // 盤面がすべて埋まったときにゲームが終了することを確認
   it('盤面がすべて埋まったときにゲームが終了することを確認', () => {
-    let state = createInitialState();
+    const state = createInitialState();
     // For simplicity, let's manually fill the board for this test
     for (let r = 0; r < 8; r++) {
       for (let c = 0; c < 8; c++) {
@@ -92,7 +92,7 @@ describe('Reversi Core Logic', () => {
 
     // 両プレイヤーともに有効な手がない場合にゲームが終了することを確認
   it('両プレイヤーともに有効な手がない場合にゲームが終了することを確認', () => {
-    let state: GameState = {
+    const state: GameState = {
       board: [
         [null, null, null, null, null, null, null, null],
         [null, null, null, null, null, null, null, null],
@@ -122,7 +122,7 @@ describe('Reversi Core Logic', () => {
 
   // 勝者が正しく決定されることを確認
   it('勝者が正しく決定されることを確認', () => {
-    let state = createInitialState();
+    const state = createInitialState();
     // Simulate a game where Black wins
     state.scores.BLACK = 30;
     state.scores.WHITE = 10;

--- a/games/stick-taking/core.test.ts
+++ b/games/stick-taking/core.test.ts
@@ -166,7 +166,7 @@ describe('棒消しゲームのコアロジック', () => {
     });
 
     it('getHintDataがすべての棒がなくなったときに0を返すこと', () => {
-      let state = createInitialState('easy');
+      const state = createInitialState('easy');
       state.rows = state.rows.map(row =>
         row.map(stick => ({...stick, isTaken: true}))
       );

--- a/games/tictactoe/core.test.ts
+++ b/games/tictactoe/core.test.ts
@@ -120,7 +120,7 @@ describe('Tic-Tac-Toe Core Logic', () => {
   });
 
   it('引き分けを検出することを確認', () => {
-    let state: GameState | null = createInitialState();
+    const state: GameState | null = createInitialState();
     if (!state) return;
     // Manually set up a draw board state
     state.board = [

--- a/hooks/useGameStateLogger.ts
+++ b/hooks/useGameStateLogger.ts
@@ -5,7 +5,7 @@ interface LogEntry {
   timestamp: number;
   component: string;
   event: string;
-  data: any;
+  data: unknown;
   stackTrace?: string;
 }
 
@@ -13,7 +13,7 @@ class GameStateLogger {
   private logs: LogEntry[] = [];
   private maxLogs = 100;
 
-  log(component: string, event: string, data: any) {
+  log(component: string, event: string, data: unknown) {
     const entry: LogEntry = {
       timestamp: Date.now(),
       component,
@@ -56,10 +56,10 @@ const gameStateLogger = new GameStateLogger();
 // React hook for logging game state changes
 export function useGameStateLogger(
   component: string,
-  gameState: BaseGameState | any,
-  additionalData?: any
+  gameState: BaseGameState | Record<string, unknown>,
+  additionalData?: unknown
 ) {
-  const prevStateRef = useRef<any>(null);
+  const prevStateRef = useRef<unknown>(null);
   const mountedRef = useRef(false);
 
   useEffect(() => {
@@ -93,7 +93,7 @@ export function useGameStateLogger(
   }, [component, gameState, additionalData]);
 
   return {
-    log: (event: string, data: any) => gameStateLogger.log(component, event, data),
+    log: (event: string, data: unknown) => gameStateLogger.log(component, event, data),
     getLogs: () => gameStateLogger.getLogs(),
     getComponentLogs: () => gameStateLogger.getLogsForComponent(component),
     clearLogs: () => gameStateLogger.clearLogs(),
@@ -104,7 +104,7 @@ export function useGameStateLogger(
 // Hook for manual logging
 export function useGameLogger(component: string) {
   return {
-    log: (event: string, data: any) => gameStateLogger.log(component, event, data),
+    log: (event: string, data: unknown) => gameStateLogger.log(component, event, data),
     getLogs: () => gameStateLogger.getLogs(),
     getComponentLogs: () => gameStateLogger.getLogsForComponent(component),
     clearLogs: () => gameStateLogger.clearLogs(),

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev -H 0.0.0.0",
     "build": "next build",
     "test": "npm run test:lint && npm run test:license && npm run test:unit && npm run test:e2e",
-    "test:lint": "next lint",
+    "test:lint": "eslint .",
     "test:license": "npx license-checker --production --summary --failOn \"GPL, AGPL\"",
     "test:unit": "vitest run",
     "test:unit-ui": "vitest --ui",

--- a/scripts/license-update.js
+++ b/scripts/license-update.js
@@ -1,5 +1,5 @@
-const fs = require('fs');
-const { execSync } = require('child_process');
+import fs from 'fs';
+import { exit } from 'process';
 
 // NOTE: This script is intended to be run with `npx license-checker --production --json` piped to stdin.
 // Example: npx license-checker --production --json | node scripts/license-update.js
@@ -43,5 +43,5 @@ This file contains the licenses for the libraries used in this project.
 } catch (error) {
   console.error('Failed to generate license file. Is the JSON from license-checker being piped correctly?');
   console.error(error);
-  process.exit(1);
+  exit(1);
 }

--- a/types/game.test.ts
+++ b/types/game.test.ts
@@ -10,6 +10,8 @@ import {
   GameController,
 } from './game';
 
+type DummyAction = { type: 'DUMMY' };
+
 describe('ヒント機能の型定義', () => {
   it('Position型が正しく定義されている', () => {
     const position: Position = { row: 1, col: 2 };
@@ -64,7 +66,7 @@ describe('ヒント機能の型定義', () => {
 
   it('HintableGameController型が正しく定義されている', () => {
     // モックのコントローラーを作成
-    const mockController: HintableGameController<HintableGameState, any> = {
+    const mockController: HintableGameController<HintableGameState, DummyAction> = {
       gameState: {
         status: 'playing',
         currentPlayer: 'player1',
@@ -87,7 +89,7 @@ describe('ヒント機能の型定義', () => {
 
   it('GameController型の型ガードが正しく動作する', () => {
     // ベースコントローラー
-    const baseController: BaseGameController<BaseGameState, any> = {
+    const baseController: BaseGameController<BaseGameState, DummyAction> = {
       gameState: { status: 'waiting', currentPlayer: null, winner: null },
       dispatch: () => {},
       resetGame: () => {},
@@ -95,7 +97,7 @@ describe('ヒント機能の型定義', () => {
     };
 
     // ヒント機能付きコントローラー
-    const hintController: HintableGameController<HintableGameState, any> = {
+    const hintController: HintableGameController<HintableGameState, DummyAction> = {
       gameState: {
         status: 'playing',
         currentPlayer: 'player1',
@@ -110,7 +112,7 @@ describe('ヒント機能の型定義', () => {
     };
 
     // GameController型として扱える
-    const controllers: GameController<any, any>[] = [baseController, hintController];
+    const controllers: GameController<BaseGameState, DummyAction>[] = [baseController, hintController];
     expect(controllers).toHaveLength(2);
   });
 });

--- a/types/game.ts
+++ b/types/game.ts
@@ -69,7 +69,7 @@ export interface HintableGameState extends BaseGameState {
 
 // 履歴機能付きゲーム状態
 export interface HistoryGameState extends BaseGameState {
-  history: any[]; // ゲーム固有の履歴データ
+  history: unknown[]; // ゲーム固有の履歴データ
   currentHistoryIndex: number;
 }
 


### PR DESCRIPTION
  next lintの非推奨化に対応するため、eslint .に移行しました。
  移行に伴い、新たに検出されたlintエラーを修正しました。

  主な変更点:
   - package.jsonのtest:lintスクリプトをnext lintからeslint .に変更
   - eslint.config.mjsにNext.jsの推奨ignores設定を追加
   - no-explicit-anyやrules-of-hooksなどのlintエラーを修正

  変更後は、開発ワークフローのルールに従い npm run test と npm run build
  を実行し、すべてのチェックが通ることを確認済みです。